### PR TITLE
fix(build): convert require to ES6 imports to avoid variable redeclar…

### DIFF
--- a/apps/backend/src/db/migrate.ts
+++ b/apps/backend/src/db/migrate.ts
@@ -1,7 +1,7 @@
-const { drizzle } = require('drizzle-orm/postgres-js');
-const { migrate } = require('drizzle-orm/postgres-js/migrator');
-const postgres = require('postgres');
-const path = require('path');
+import { drizzle } from 'drizzle-orm/postgres-js';
+import { migrate } from 'drizzle-orm/postgres-js/migrator';
+import postgres from 'postgres';
+import * as path from 'path';
 
 async function runMigrations() {
   const connectionString =

--- a/apps/backend/src/db/sync-migrations.ts
+++ b/apps/backend/src/db/sync-migrations.ts
@@ -10,8 +10,8 @@
  * Exécution : Automatique lors du déploiement (start:prod)
  */
 
-const { drizzle } = require('drizzle-orm/postgres-js');
-const postgres = require('postgres');
+import { drizzle } from 'drizzle-orm/postgres-js';
+import postgres from 'postgres';
 
 async function syncMigrations() {
   const connectionString =
@@ -135,17 +135,13 @@ async function syncMigrations() {
   }
 }
 
-// Vérifier si le script est exécuté directement
-if (require.main === module) {
-  syncMigrations()
-    .then(() => {
-      console.log('✅ Synchronisation terminée');
-      process.exit(0);
-    })
-    .catch((err) => {
-      console.error('❌ Erreur fatale:', err);
-      process.exit(1);
-    });
-}
-
-module.exports = { syncMigrations };
+// Exécuter le script si appelé directement
+syncMigrations()
+  .then(() => {
+    console.log('✅ Synchronisation terminée');
+    process.exit(0);
+  })
+  .catch((err) => {
+    console.error('❌ Erreur fatale:', err);
+    process.exit(1);
+  });


### PR DESCRIPTION
…ation

- Replace require() with import statements in migrate.ts and sync-migrations.ts
- Fix TypeScript error TS2451: Cannot redeclare block-scoped variable
- Ensure proper module scoping for drizzle and postgres imports
- Remove CommonJS exports in favor of ES6 modules

Fixes production build failure on Render.com