### PR TITLE
fix(postgres): handle CommonJS/ESM interop for postgres package

### DIFF
--- a/apps/backend/src/db/migrate.ts
+++ b/apps/backend/src/db/migrate.ts
@@ -15,7 +15,9 @@ async function runMigrations() {
     connectionString.includes('localhost') ||
     connectionString.includes('127.0.0.1');
 
-  const sql = postgres(connectionString, {
+  // @ts-ignore - postgres package has CommonJS/ESM interop issues
+  const postgresConnect = postgres.default || postgres;
+  const sql = postgresConnect(connectionString, {
     max: 1,
     ssl: isLocalDatabase ? false : 'require',
   });

--- a/apps/backend/src/db/sync-migrations.ts
+++ b/apps/backend/src/db/sync-migrations.ts
@@ -24,7 +24,9 @@ async function syncMigrations() {
     connectionString.includes('localhost') ||
     connectionString.includes('127.0.0.1');
 
-  const sql = postgres(connectionString, {
+  // @ts-ignore - postgres package has CommonJS/ESM interop issues
+  const postgresConnect = postgres.default || postgres;
+  const sql = postgresConnect(connectionString, {
     max: 1,
     ssl: isLocalDatabase ? false : 'require',
   });


### PR DESCRIPTION
- Add fallback: postgres.default || postgres to handle both module systems
- Fixes TypeError: (0, postgres_1.default) is not a function
- Add @ts-ignore for known interop issue
- Ensures compatibility in both compiled and runtime environments

This resolves the postgres import issue in production deployment on Render.