### PR TITLE
fix(postgres): use require() directly for CommonJS compatibility

### DIFF
--- a/apps/backend/src/db/migrate.ts
+++ b/apps/backend/src/db/migrate.ts
@@ -1,6 +1,5 @@
 import { drizzle } from 'drizzle-orm/postgres-js';
 import { migrate } from 'drizzle-orm/postgres-js/migrator';
-import postgres from 'postgres';
 import * as path from 'path';
 
 async function runMigrations() {
@@ -15,9 +14,10 @@ async function runMigrations() {
     connectionString.includes('localhost') ||
     connectionString.includes('127.0.0.1');
 
-  // @ts-ignore - postgres package has CommonJS/ESM interop issues
-  const postgresConnect = postgres.default || postgres;
-  const sql = postgresConnect(connectionString, {
+  // Use require directly for CommonJS compatibility in production
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const postgres = require('postgres');
+  const sql = postgres(connectionString, {
     max: 1,
     ssl: isLocalDatabase ? false : 'require',
   });

--- a/apps/backend/src/db/sync-migrations.ts
+++ b/apps/backend/src/db/sync-migrations.ts
@@ -11,7 +11,6 @@
  */
 
 import { drizzle } from 'drizzle-orm/postgres-js';
-import postgres from 'postgres';
 
 async function syncMigrations() {
   const connectionString =
@@ -24,9 +23,10 @@ async function syncMigrations() {
     connectionString.includes('localhost') ||
     connectionString.includes('127.0.0.1');
 
-  // @ts-ignore - postgres package has CommonJS/ESM interop issues
-  const postgresConnect = postgres.default || postgres;
-  const sql = postgresConnect(connectionString, {
+  // Use require directly for CommonJS compatibility in production
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const postgres = require('postgres');
+  const sql = postgres(connectionString, {
     max: 1,
     ssl: isLocalDatabase ? false : 'require',
   });


### PR DESCRIPTION
- Remove ES6 import for postgres package causing interop issues
- Use require('postgres') directly in migration scripts
- Avoids undefined default export errors in production
- Simpler, more reliable approach for CommonJS packages

Fixes: Cannot read properties of undefined (reading 'default') This is the final fix for postgres module loading in production.