### PR TITLE
fix(migrations): correct drizzle folder path in production

### DIFF
--- a/apps/backend/src/db/migrate.ts
+++ b/apps/backend/src/db/migrate.ts
@@ -26,10 +26,8 @@ async function runMigrations() {
     console.log('🚀 Running Drizzle migrations...');
 
     // Déterminer le dossier de migrations
-    const migrationsFolder =
-      process.env.NODE_ENV === 'production'
-        ? path.resolve(__dirname, '../../dist/drizzle')
-        : path.resolve(__dirname, '../../drizzle');
+    // En production, __dirname = dist/src/db, donc ../../drizzle = dist/drizzle
+    const migrationsFolder = path.resolve(__dirname, '../../drizzle');
 
     console.log('📁 Migrations folder:', migrationsFolder);
 


### PR DESCRIPTION
- Remove duplicate 'dist/' in migrations folder path
- __dirname in production already points to dist/src/db
- ../../drizzle correctly resolves to dist/drizzle (not dist/dist/drizzle)
- Fixes: Can't find meta/_journal.json file

The build script copies drizzle/ to dist/drizzle, so in production we should use ../../drizzle from dist/src/db directory.